### PR TITLE
Exposing LocalizedStrings<T> in TypeScript definition

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -2,12 +2,12 @@ declare module 'react-localization' {
     type Formatted = number | string | JSX.Element;
     type FormatObject<U extends Formatted> = { [key: string]: U };
     
-    export interface GlobalStrings<T> {		
-      [language: string]: T;		
+    export interface GlobalStrings<T> {        
+      [language: string]: T;        
     }
     
   
-    interface LocalizedStringsMethods {
+    export interface LocalizedStringsMethods {
         setLanguage(language: string): void;
         getLanguage(): string;
         getInterfaceLanguage(): string;
@@ -16,11 +16,13 @@ declare module 'react-localization' {
         getString(key: string, language: string): string;
         setContent(props: any): void;
     }
+
+    export type LocalizedStrings<T> = LocalizedStringsMethods & T;
   
     interface LocalizedStringsFactory {
-        new <T>(props: GlobalStrings<T>): LocalizedStringsMethods & T;
+        new <T>(props: GlobalStrings<T>): LocalizedStrings<T>;
     }
   
-    var LocalizedStrings: LocalizedStringsFactory;
-    export default LocalizedStrings;
+    var LocalizedStringsFactory: LocalizedStringsFactory;
+    export default LocalizedStringsFactory;
   }


### PR DESCRIPTION
The interface `LocalizedStringsMethods` is not exported which reduces how far it's type information carries..

## Example

#### Data.ts
```
export interface Data {
    helloWorld: string;
}
```

#### LocalizationService.ts
```
import { default as LocalizedStrings, GlobalStrings} from 'react-localization';

const locaizationData: GlobalStrings<Data> = {
    'en': {
        'helloWorld': 'Hello World!',
    }
};

const localizations = new LocalizedStrings(localizationData);

console.log(localizations.helloWorld);
// ^ Everything is fine here
localizations.setLanguage('en');
// ^ Everything is fine here

export { localizations };
```

#### UserInterface.ts

```
import { Content } from './Content';
import { localizations } from './LocalizationService';

console.log(localizations.helloWorld);
// ^ Everything is fine here
localizations.setLanguage('en');
// ^ This does not work
```
`localizations` is of type `Content` and the methods on `LocalizedStringsMethods` do not exist.

## After this pull request

#### Data.ts
```
export interface Data {
    helloWorld: string;
}
```

#### LocalizationService.ts
```
import { Data} from './Data';
import { default as LocalizedStringsFactory, GlobalStrings} from 'react-localization';


const locaizationData: GlobalStrings<Data> = {
    'en': {
        'helloWorld': 'Hello World!',
    }
};
// ^ The type information explicitly for the example's sake

const localizations : LocalizedStrings<Data> = new LocalizedStringsFactory(localizationData);
// ^ The type information explicitly for the example's sake

console.log(localizations.helloWorld);
// ^ Everything is fine here
localizations.setLanguage('en');
// ^ Everything is fine here

export { localizations };
```

#### UserInterface.ts

```
import { Data } from './Data';
import { localizations } from './LocalizationService';

console.log(localizations.helloWorld);
// ^ Everything is fine here
localizations.setLanguage('en');
// ^ This works now too
```
`localizations` is of correct type `LocalizedStrings<Data>` which is the union of `LocalizedStringsMethods`  and `Data`.